### PR TITLE
Add support for the @FetchRequest property wrapper

### DIFF
--- a/PredicateKit.podspec
+++ b/PredicateKit.podspec
@@ -15,7 +15,7 @@
 
 Pod::Spec.new do |spec|
   spec.name = "PredicateKit"
-  spec.version = "1.1.0"
+  spec.version = "1.2.0"
   spec.summary = "Write expressive and type-safe predicates for CoreData using key-paths, comparisons and logical operators, literal values, and functions."
   spec.description = <<-DESC
   PredicateKit allows Swift developers to write expressive and type-safe predicates for CoreData using key-paths, comparisons and logical operators, literal values, and functions.

--- a/PredicateKit.xcodeproj/project.pbxproj
+++ b/PredicateKit.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		320347252549A66E00F9661B /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 320347242549A66E00F9661B /* README.md */; };
 		3203472D254C952600F9661B /* NSFetchRequestInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3203472C254C952500F9661B /* NSFetchRequestInspector.swift */; };
 		32034735254CC05300F9661B /* MockNSFetchRequestInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32034734254CC05300F9661B /* MockNSFetchRequestInspector.swift */; };
+		32C8F72325B22CBE00903E22 /* SwiftUISupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C8F72225B22CBE00903E22 /* SwiftUISupport.swift */; };
+		32C8F75525B248C700903E22 /* SwiftUISupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +57,8 @@
 		320347242549A66E00F9661B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3203472C254C952500F9661B /* NSFetchRequestInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSFetchRequestInspector.swift; sourceTree = "<group>"; };
 		32034734254CC05300F9661B /* MockNSFetchRequestInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNSFetchRequestInspector.swift; sourceTree = "<group>"; };
+		32C8F72225B22CBE00903E22 /* SwiftUISupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupport.swift; sourceTree = "<group>"; };
+		32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupportTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				320346842546B62A00F9661B /* CoreData */,
+				32C8F72125B22C9D00903E22 /* SwiftUI */,
 				320347122548EE4B00F9661B /* Functions.swift */,
 				320346602546AA5400F9661B /* Info.plist */,
 				3203467C2546AB9A00F9661B /* Primitive.swift */,
@@ -113,6 +118,7 @@
 			children = (
 				320346EE25470EA200F9661B /* CoreDataTests */,
 				329BCA602550DB220089D8B6 /* Resources */,
+				32C8F75325B248B400903E22 /* SwiftUITests */,
 				3203466C2546AA5400F9661B /* Info.plist */,
 				320346E825470CA700F9661B /* OperatorTests.swift */,
 				320346E02547073A00F9661B /* PrimitiveTests.swift */,
@@ -155,6 +161,22 @@
 				3203470D2548C54200F9661B /* DataModel.xcdatamodeld */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		32C8F72125B22C9D00903E22 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				32C8F72225B22CBE00903E22 /* SwiftUISupport.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
+		32C8F75325B248B400903E22 /* SwiftUITests */ = {
+			isa = PBXGroup;
+			children = (
+				32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */,
+			);
+			path = SwiftUITests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -268,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				320346862546B70000F9661B /* NSManagedObjectContextExtensions.swift in Sources */,
+				32C8F72325B22CBE00903E22 /* SwiftUISupport.swift in Sources */,
 				3203470225483A8500F9661B /* NSFetchRequestBuilder.swift in Sources */,
 				3203472D254C952600F9661B /* NSFetchRequestInspector.swift in Sources */,
 				320346812546ABB900F9661B /* Predicate.swift in Sources */,
@@ -287,6 +310,7 @@
 				320346E925470CA700F9661B /* OperatorTests.swift in Sources */,
 				32034719254903B700F9661B /* XCTestCaseExtensions.swift in Sources */,
 				320346E12547073A00F9661B /* PrimitiveTests.swift in Sources */,
+				32C8F75525B248C700903E22 /* SwiftUISupportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PredicateKit/SwiftUI/SwiftUISupport.swift
+++ b/PredicateKit/SwiftUI/SwiftUISupport.swift
@@ -28,6 +28,18 @@ extension SwiftUI.FetchRequest where Result: NSManagedObject {
   /// - Parameter predicate: The predicate used to define a filter for the fetched results.
   /// - Parameter animation: The animation used for any changes to the fetched results.
   ///
+  /// ## Example
+  ///
+  ///     struct ContentView: View {
+  ///       @SwiftUI.FetchRequest(predicate: \Note.text == "Hello, World!")
+  ///       var notes: FetchedResults<Note>
+  ///
+  ///       var body: some View {
+  ///         List(notes, id: \.self) {
+  ///           Text($0.text)
+  ///         }
+  ///       }
+  ///
   public init(predicate: Predicate<Result>, animation: Animation? = nil) {
     self.init(fetchRequest: FetchRequest(predicate: predicate), animation: animation)
   }
@@ -36,6 +48,23 @@ extension SwiftUI.FetchRequest where Result: NSManagedObject {
   ///
   /// - Parameter fetchRequest: The request used to produce the fetched results.
   /// - Parameter animation: The animation used for any changes to the fetched results.
+  ///
+  /// ## Example
+  ///
+  ///     struct ContentView: View {
+  ///       @SwiftUI.FetchRequest(
+  ///         fetchRequest: FetchRequest(predicate: (\Note.text).contains("Hello, World!"))
+  ///           .limit(50)
+  ///           .offset(100)
+  ///           .sorted(by: \.Note.creationDate)
+  ///       )
+  ///       var notes: FetchedResults<Note>
+  ///
+  ///       var body: some View {
+  ///         List(notes, id: \.self) {
+  ///           Text($0.text)
+  ///         }
+  ///       }
   ///
   public init(fetchRequest: FetchRequest<Result>, animation: Animation? = nil) {
     let entityName = Result.entity().name ?? String(describing: Result.self)
@@ -48,6 +77,22 @@ extension SwiftUI.FetchRequest where Result: NSManagedObject {
   /// - Parameter fetchRequest: The request used to produce the fetched results.
   /// - Parameter transaction: The transaction used for any changes to the fetched results.
   ///
+  /// ## Example
+  ///
+  ///      struct ContentView: View {
+  ///        @SwiftUI.FetchRequest(
+  ///          fetchRequest: FetchRequest(predicate: \Note.text == "Hello, World!")),
+  ///          transaction: Transaction(animation: .easeIn)
+  ///        )
+  ///        var notes: FetchedResults<Note>
+  ///
+  ///        var body: some View {
+  ///          List(notes, id: \.self) {
+  ///            Text($0.text)
+  ///          }
+  ///        }
+  ///      }
+  ///
   public init(fetchRequest: FetchRequest<Result>, transaction: Transaction) {
     let entityName = Result.entity().name ?? String(describing: Result.self)
     let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
@@ -59,9 +104,28 @@ extension SwiftUI.FetchRequest where Result: NSManagedObject {
 extension FetchRequest {
   /// Creates a fetch request using the provided predicate.
   ///
+  /// - Parameter predicate: The predicate used to define a filter for the fetched results.
+  ///
   /// - Important: Use this initializer **only** in conjunction with the SwiftUI property wrapper` @FetchRequest`. Fetch
   ///   requests created with this initializer cannot be executed outside of SwiftUI as they rely on the CoreData
   ///   managed object context injected in the environment of a SwiftUI view.
+  ///
+  /// ## Example
+  ///
+  ///       struct ContentView: View {
+  ///        @SwiftUI.FetchRequest(
+  ///          fetchRequest: FetchRequest(predicate: (\Note.text).contains("Hello, World!"))
+  ///            .sorted(by: \Note.creationDate, .ascending)
+  ///            .limit(100)
+  ///        )
+  ///        var notes: FetchedResults<Note>
+  ///
+  ///        var body: some View {
+  ///          List(notes, id: \.self) {
+  ///            Text($0.text)
+  ///          }
+  ///        }
+  ///      }
   ///
   public init(predicate: Predicate<Entity>) {
     let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)

--- a/PredicateKit/SwiftUI/SwiftUISupport.swift
+++ b/PredicateKit/SwiftUI/SwiftUISupport.swift
@@ -128,6 +128,9 @@ extension FetchRequest {
   ///      }
   ///
   public init(predicate: Predicate<Entity>) {
+    // It's okay to provide this "default" context. It will not be used; instead SwiftUI will
+    // use the context injected in the environment of the view to execute the created
+    // fetch request.
     let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
     self.init(context: context, predicate: predicate)
   }

--- a/PredicateKit/SwiftUI/SwiftUISupport.swift
+++ b/PredicateKit/SwiftUI/SwiftUISupport.swift
@@ -1,0 +1,70 @@
+//
+//  SwiftUISupport.swift
+//  PredicateKit
+//
+//  Copyright 2021 Faiçal Tchirou
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+//  documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+//  to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+//  the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import CoreData
+import SwiftUI
+
+@available(iOS 13.0, *)
+extension SwiftUI.FetchRequest where Result: NSManagedObject {
+  /// Creates an instance by defining a fetch request based on the provided predicate and animation.
+  ///
+  /// - Parameter predicate: The predicate used to define a filter for the fetched results.
+  /// - Parameter animation: The animation used for any changes to the fetched results.
+  ///
+  public init(predicate: Predicate<Result>, animation: Animation? = nil) {
+    self.init(fetchRequest: FetchRequest(predicate: predicate), animation: animation)
+  }
+
+  /// Creates an instance from the provided fetch request and animation.
+  ///
+  /// - Parameter fetchRequest: The request used to produce the fetched results.
+  /// - Parameter animation: The animation used for any changes to the fetched results.
+  ///
+  public init(fetchRequest: FetchRequest<Result>, animation: Animation? = nil) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    self.init(fetchRequest: fetchRequestBuilder.makeRequest(from: fetchRequest), animation: animation)
+  }
+
+  /// Creates an instance from the provided fetch request and transaction.
+  ///
+  /// - Parameter fetchRequest: The request used to produce the fetched results.
+  /// - Parameter transaction: The transaction used for any changes to the fetched results.
+  ///
+  public init(fetchRequest: FetchRequest<Result>, transaction: Transaction) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    self.init(fetchRequest: fetchRequestBuilder.makeRequest(from: fetchRequest), transaction: transaction)
+  }
+}
+
+@available(iOS 13.0, *)
+extension FetchRequest {
+  /// Creates a fetch request using the provided predicate.
+  ///
+  /// - Important: Use this initializer **only** in conjunction with the SwiftUI property wrapper` @FetchRequest`. Fetch
+  ///   requests created with this initializer cannot be executed outside of SwiftUI as they rely on the CoreData
+  ///   managed object context injected in the environment of a SwiftUI view.
+  ///
+  public init(predicate: Predicate<Entity>) {
+    let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+    self.init(context: context, predicate: predicate)
+  }
+}

--- a/PredicateKitTests/SwiftUITests/SwiftUISupportTests.swift
+++ b/PredicateKitTests/SwiftUITests/SwiftUISupportTests.swift
@@ -1,0 +1,201 @@
+//
+//  SwiftUISupportTests.swift
+//  PredicateKitTests
+//
+//  Copyright 2021 Faiçal Tchirou
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+//  documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+//  to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+//  the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+//  OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+//  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import CoreData
+import Foundation
+import SwiftUI
+import XCTest
+
+@testable import PredicateKit
+
+// Basic tests to ensure that predicates and fetch requests passed to SwiftUI's `FetchRequest` end up in the
+// view's graph. We don't really test here that our `Predicate`s and `FetchRequest`s are properly converted to
+// `NSPredicate`s and `NSFetchRequest`s; we rely on the tests in `NSFetchRequestBuilderTests` and assume the conversion
+// correctness. Here, we just want to ensure that the view's graph will contain the expected `NSFetchRequest`.
+@available(iOS 13.0, *)
+class SwiftUISupportTests: XCTestCase {
+  func testFetchRequestPropertyWrapperWithBasicPredicate() throws {
+    struct ContentView: View {
+      @SwiftUI.FetchRequest(predicate: \Note.text == "Hello, World!")
+      var notes: FetchedResults<Note>
+
+      var body: some View {
+        List(notes, id: \.self) {
+          Text($0.text)
+        }
+      }
+    }
+
+    let view = ContentView().environment(\.managedObjectContext, .default)
+    let request = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "fetchRequest") as? NSFetchRequest<Note>
+    )
+
+    let comparison = try XCTUnwrap(request.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "text"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: "Hello, World!"))
+    XCTAssertEqual(comparison.predicateOperatorType, .equalTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testFetchRequestPropertyWrapperWithPredicateAndSortDescriptors() throws {
+    struct ContentView: View {
+      @SwiftUI.FetchRequest(
+        fetchRequest: FetchRequest(predicate: \Note.creationDate < .now)
+          .sorted(by: \.text, .ascending)
+          .sorted(by: \.creationDate, .descending)
+      )
+      var notes: FetchedResults<Note>
+
+      var body: some View {
+        List(notes, id: \.self) {
+          Text($0.text)
+        }
+      }
+    }
+
+    let view = ContentView().environment(\.managedObjectContext, .default)
+    let request = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "fetchRequest") as? NSFetchRequest<Note>
+    )
+
+    let comparison = try XCTUnwrap(request.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "creationDate"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: Date.now))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+
+    let sortDescriptors = try XCTUnwrap(request.sortDescriptors)
+    XCTAssertEqual(sortDescriptors.count, 2)
+    XCTAssertEqual(sortDescriptors.first?.key, "text")
+    XCTAssertTrue(sortDescriptors.first?.ascending ?? false)
+    XCTAssertEqual(sortDescriptors.last?.key, "creationDate")
+    XCTAssertFalse(sortDescriptors.last?.ascending ?? true)
+  }
+
+  func testFetchRequestPropertyWrapperWithBasicModifier() throws {
+    struct ContentView: View {
+      @SwiftUI.FetchRequest(
+        fetchRequest: FetchRequest(predicate: \Note.creationDate < .now)
+          .limit(100)
+      )
+      var notes: FetchedResults<Note>
+
+      var body: some View {
+        List(notes, id: \.self) {
+          Text($0.text)
+        }
+      }
+    }
+
+    let view = ContentView().environment(\.managedObjectContext, .default)
+    let request = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "fetchRequest") as? NSFetchRequest<Note>
+    )
+
+    let comparison = try XCTUnwrap(request.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "creationDate"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: Date.now))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+    XCTAssertEqual(request.fetchLimit, 100)
+  }
+
+  func testFetchRequestPropertyWrapperWithAnimation() throws {
+    struct ContentView: View {
+      @SwiftUI.FetchRequest(predicate: \Note.numberOfViews == 42, animation: .easeIn)
+      var notes: FetchedResults<Note>
+
+      var body: some View {
+        List(notes, id: \.self) {
+          Text($0.text)
+        }
+      }
+    }
+
+    let view = ContentView().environment(\.managedObjectContext, .default)
+    let request = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "fetchRequest") as? NSFetchRequest<Note>
+    )
+
+    let transaction = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "transaction") as? Transaction
+    )
+    XCTAssertEqual(transaction.animation, .easeIn)
+
+    let comparison = try XCTUnwrap(request.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "numberOfViews"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: 42))
+    XCTAssertEqual(comparison.predicateOperatorType, .equalTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testFetchRequestPropertyWrapperWithTransaction() throws {
+    struct ContentView: View {
+      @SwiftUI.FetchRequest(
+        fetchRequest: FetchRequest(predicate: \Note.text == "Hello, World!"),
+        transaction: .nonContinuousEaseInOut
+      )
+      var notes: FetchedResults<Note>
+
+      var body: some View {
+        List(notes, id: \.self) {
+          Text($0.text)
+        }
+      }
+    }
+
+    let view = ContentView().environment(\.managedObjectContext, .default)
+    let request = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "fetchRequest") as? NSFetchRequest<Note>
+    )
+
+    let transaction = try XCTUnwrap(
+      Mirror(reflecting: view).descendant("content", "_notes", "transaction") as? Transaction
+    )
+    XCTAssertEqual(transaction.animation, .easeInOut)
+    XCTAssertFalse(transaction.isContinuous)
+
+    let comparison = try XCTUnwrap(request.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "text"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: "Hello, World!"))
+    XCTAssertEqual(comparison.predicateOperatorType, .equalTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+}
+
+// MARK: -
+
+private extension NSManagedObjectContext {
+  static let `default` = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+}
+
+private extension Date {
+  static let now = Date()
+}
+
+@available(iOS 13.0, *)
+private extension Transaction {
+  static var nonContinuousEaseInOut: Transaction = {
+    var transaction = Transaction(animation: .easeInOut)
+    transaction.isContinuous = false
+    return transaction
+  }()
+}

--- a/README.md
+++ b/README.md
@@ -231,7 +231,10 @@ struct ContentView: View {
 
 ## Fetching objects with an NSFetchedResultsController
 
-In UIKit, you can use `fetchedResultsController()` to create an `NSFetchedResultsController` from a configured fetch request. `fetchedResultsController` has two optional parameters: `sectionNameKeyPath` is a [key-path](https://developer.apple.com/documentation/swift/keypath) on the returned objects used to compute section info and `cacheName` is the name of a file to store pre-computed section info.
+In UIKit, you can use `fetchedResultsController()` to create an `NSFetchedResultsController` from a configured fetch request. `fetchedResultsController` has two optional parameters: 
+
+- `sectionNameKeyPath` is a [key-path](https://developer.apple.com/documentation/swift/keypath) on the returned objects used to compute section info
+- `cacheName` is the name of a file to store pre-computed section info.
 
 ###### Example
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ comparisons and logical operators, literal values, and functions.
   - [Fetching objects](#fetching-objects)
   - [Configuring the fetch](#configuring-the-fetch)
   - [Fetching objects with an NSFetchedResultsController](#fetching-objects-with-an-nsfetchedresultscontroller)
+  - [Fetching objects with the @FetchRequest property wrapper](#fetching-objects-with-the-fetchrequest-property-wrapper)
   - [Counting objects](#counting-objects)
 - [Documentation](#documentation)
   - [Writing predicates](#writing-predicates)
@@ -155,9 +156,79 @@ let notes: [Note] = try managedObjectContext
 
 See [Request modifiers](#request-modifiers) for more about modifiers.
 
+## Fetching objects with the @FetchRequest property wrapper
+
+PredicateKit extends the SwiftUI [ `@FetchRequest`](https://developer.apple.com/documentation/swiftui/fetchrequest) property wrapper to support type-safe predicates. To use, simply initialize a `@FetchRequest` with a predicate.
+
+###### Example
+
+```swift
+import PredicateKit
+import SwiftUI
+
+struct ContentView: View {
+
+  @SwiftUI.FetchRequest(predicate: \Note.text == "Hello, World!")
+  var notes: FetchedResults<Note>
+
+  var body: some View {
+    List(notes, id: \.self) {
+      Text($0.text)
+    }
+  }
+}
+```
+
+You can also initialize a `@FetchRequest` with a full-fledged request with modifiers and sort descriptors.
+
+###### Example
+
+```swift
+import PredicateKit
+import SwiftUI
+
+struct ContentView: View {
+
+  @SwiftUI.FetchRequest(
+    fetchRequest: FetchRequest(predicate: (\Note.text).contains("Hello, World!"))
+      .limit(50)
+      .offset(100)
+      .sorted(by: \.Note.creationDate)
+  )
+  var notes: FetchedResults<Note>
+
+  var body: some View {
+    List(notes, id: \.self) {
+      Text($0.text)
+    }
+  }
+}
+```
+
+Both initializers accept an optional parameter `animation` that will be used to animate changes in the fetched results.
+
+###### Example
+
+```swift
+import PredicateKit
+import SwiftUI
+
+struct ContentView: View {
+
+  @SwiftUI.FetchRequest(predicate: (\Note.text).contains("Hello, World!"), animation: .easeInOut)
+  var notes: FetchedResults<Note>
+
+  var body: some View {
+    List(notes, id: \.self) {
+      Text($0.text)
+    }
+  }
+}
+```
+
 ## Fetching objects with an NSFetchedResultsController
 
-Instead of directly fetching results, you can use `fetchedResultsController()` to instantiate an `NSFetchedResultsController` with the configured fetch. `fetchedResultsController` has two optional parameters: `sectionNameKeyPath` is a [key-path](https://developer.apple.com/documentation/swift/keypath) on the returned objects used to compute section info and `cacheName` is the name of a file to store pre-computed section info.
+In UIKit, you can use `fetchedResultsController()` to create an `NSFetchedResultsController` from a configured fetch request. `fetchedResultsController` has two optional parameters: `sectionNameKeyPath` is a [key-path](https://developer.apple.com/documentation/swift/keypath) on the returned objects used to compute section info and `cacheName` is the name of a file to store pre-computed section info.
 
 ###### Example
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ comparisons and logical operators, literal values, and functions.
 - [Quick start](#quick-start)
   - [Fetching objects](#fetching-objects)
   - [Configuring the fetch](#configuring-the-fetch)
-  - [Fetching objects with an NSFetchedResultsController](#fetching-objects-with-an-nsfetchedresultscontroller)
   - [Fetching objects with the @FetchRequest property wrapper](#fetching-objects-with-the-fetchrequest-property-wrapper)
+  - [Fetching objects with an NSFetchedResultsController](#fetching-objects-with-an-nsfetchedresultscontroller)
   - [Counting objects](#counting-objects)
 - [Documentation](#documentation)
   - [Writing predicates](#writing-predicates)
@@ -205,7 +205,7 @@ struct ContentView: View {
 }
 ```
 
-Both initializers accept an optional parameter `animation` that will be used to animate changes in the fetched results.
+Both initializers accept an optional parameter [`animation`](https://developer.apple.com/documentation/swiftui/animation) that will be used to animate changes in the fetched results.
 
 ###### Example
 
@@ -215,7 +215,10 @@ import SwiftUI
 
 struct ContentView: View {
 
-  @SwiftUI.FetchRequest(predicate: (\Note.text).contains("Hello, World!"), animation: .easeInOut)
+  @SwiftUI.FetchRequest(
+    predicate: (\Note.text).contains("Hello, World!"),
+    animation: .easeInOut
+  )
   var notes: FetchedResults<Note>
 
   var body: some View {


### PR DESCRIPTION
Enables consumers to use the SwiftUI property wrapper [`@FetchRequest`](https://developer.apple.com/documentation/swiftui/fetchrequest) with PredicateKit.

###### Example

```swift
import PredicateKit
import SwiftUI

struct ContentView: View {
  @SwiftUI.FetchRequest(predicate: \Note.text == "Hello, World!")
  var notes: FetchedResults<Note>

  var body: some View {
    List(notes, id: \.self) {
      Text($0.text)
    }
  }
}
```