### PR TITLE
allow "IN" Expression to have a list or a set as a parameter

### DIFF
--- a/PredicateKit/Predicate.swift
+++ b/PredicateKit/Predicate.swift
@@ -477,6 +477,14 @@ extension Expression where Value: Primitive {
   public func `in`(_ list: Value...) -> Predicate<Root> {
     .comparison(.init(self, .in, list))
   }
+
+  public func `in`(_ list: [Value]) -> Predicate<Root> {
+    .comparison(.init(self, .in, list))
+  }
+    
+  public func `in`(_ set: Set<Value>) -> Predicate<Root> where Value: Hashable {
+    .comparison(.init(self, .in, Array(set)))
+  }
 }
 
 extension Expression where Value: StringValue & Primitive {

--- a/PredicateKitTests/OperatorTests.swift
+++ b/PredicateKitTests/OperatorTests.swift
@@ -1335,6 +1335,49 @@ final class OperatorTests: XCTestCase {
     XCTAssertEqual(comparison.operator, .in)
     XCTAssertEqual(value, ["hello", "world", "welcome"])
   }
+    
+  func testKeyPathInArray() throws {
+    let predicate: Predicate<Data> = (\Data.text).in(["hello", "world", "welcome"])
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("text.in(['hello', 'world', 'welcome']) should result in a comparison")
+      return
+    }
+
+    guard let keyPath = comparison.expression.as(KeyPath<Data, String>.self) else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+
+    let value = try XCTUnwrap(comparison.value as? [String])
+
+    XCTAssertEqual(keyPath, \Data.text)
+    XCTAssertEqual(comparison.operator, .in)
+    XCTAssertEqual(value, ["hello", "world", "welcome"])
+  }
+
+  func testKeyPathInSet() throws {
+    let predicate: Predicate<Data> = (\Data.text).in(Set(["hello", "world", "welcome"]))
+    
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("text.in(Set(['hello', 'world', 'welcome'])) should result in a comparison")
+      return
+    }
+    
+    guard let keyPath = comparison.expression.as(KeyPath<Data, String>.self) else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+    
+    let value = try XCTUnwrap(comparison.value as? [String])
+    
+    XCTAssertEqual(keyPath, \Data.text)
+    XCTAssertEqual(comparison.operator, .in)
+    XCTAssertTrue(value.contains("hello"), "searched item '\("hello")' is missing in comparison.value")
+    XCTAssertTrue(value.contains("world"), "searched item '\("world")' is missing in comparison.value")
+    XCTAssertTrue(value.contains("welcome"), "searched item '\("welcome")' is missing in comparison.value")
+    XCTAssertEqual(value.count, 3, "IN expression had \(3) items, found \(value.count)")
+  }
   
   func testKeyPathInCaseInsensitive() throws {
     let predicate: Predicate<Data> = (\Data.text).in(["hello", "world", "welcome"], .caseInsensitive)

--- a/PredicateKitTests/OperatorTests.swift
+++ b/PredicateKitTests/OperatorTests.swift
@@ -1337,45 +1337,45 @@ final class OperatorTests: XCTestCase {
   }
     
   func testKeyPathInArray() throws {
-    let predicate: Predicate<Data> = (\Data.text).in(["hello", "world", "welcome"])
+    let predicate: Predicate<Data> = (\Data.count).in([21, 42, 63])
 
     guard case let .comparison(comparison) = predicate else {
-      XCTFail("text.in(['hello', 'world', 'welcome']) should result in a comparison")
+      XCTFail("count.in([21, 42, 63]) should result in a comparison")
       return
     }
 
-    guard let keyPath = comparison.expression.as(KeyPath<Data, String>.self) else {
+    guard let keyPath = comparison.expression.as(KeyPath<Data, Int>.self) else {
       XCTFail("the left side of the comparison should be a key path expression")
       return
     }
 
-    let value = try XCTUnwrap(comparison.value as? [String])
+    let value = try XCTUnwrap(comparison.value as? [Int])
 
-    XCTAssertEqual(keyPath, \Data.text)
+    XCTAssertEqual(keyPath, \Data.count)
     XCTAssertEqual(comparison.operator, .in)
-    XCTAssertEqual(value, ["hello", "world", "welcome"])
+    XCTAssertEqual(value, [21, 42, 63])
   }
 
   func testKeyPathInSet() throws {
-    let predicate: Predicate<Data> = (\Data.text).in(Set(["hello", "world", "welcome"]))
+    let predicate: Predicate<Data> = (\Data.count).in(Set([21, 42, 63]))
     
     guard case let .comparison(comparison) = predicate else {
-      XCTFail("text.in(Set(['hello', 'world', 'welcome'])) should result in a comparison")
+      XCTFail("count.in(Set([21, 42, 63])) should result in a comparison")
       return
     }
     
-    guard let keyPath = comparison.expression.as(KeyPath<Data, String>.self) else {
+    guard let keyPath = comparison.expression.as(KeyPath<Data, Int>.self) else {
       XCTFail("the left side of the comparison should be a key path expression")
       return
     }
     
-    let value = try XCTUnwrap(comparison.value as? [String])
+    let value = try XCTUnwrap(comparison.value as? [Int])
     
-    XCTAssertEqual(keyPath, \Data.text)
+    XCTAssertEqual(keyPath, \Data.count)
     XCTAssertEqual(comparison.operator, .in)
-    XCTAssertTrue(value.contains("hello"), "searched item '\("hello")' is missing in comparison.value")
-    XCTAssertTrue(value.contains("world"), "searched item '\("world")' is missing in comparison.value")
-    XCTAssertTrue(value.contains("welcome"), "searched item '\("welcome")' is missing in comparison.value")
+    XCTAssertTrue(value.contains(21), "searched item '\(21)' is missing in comparison.value")
+    XCTAssertTrue(value.contains(42), "searched item '\(42)' is missing in comparison.value")
+    XCTAssertTrue(value.contains(63), "searched item '\(63)' is missing in comparison.value")
     XCTAssertEqual(value.count, 3, "IN expression had \(3) items, found \(value.count)")
   }
   

--- a/README.md
+++ b/README.md
@@ -348,6 +348,19 @@ You can use the  `in`  function to determine whether a property's value is one o
 // Matches all notes where the text is one of the elements in the specified list.
 let predicate = (\Note.text).in("a", "b", "c", "d")
 ```
+or pass in an Array
+
+```swift
+// Matches all notes where the text is one of the elements in the specified list.
+let predicate = (\Note.text).in(["a", "b", "c", "d"])
+```
+
+or pass in a Set 
+
+```swift
+// Matches all notes where the text is one of the elements in the specified list.
+let predicate = (\Note.text).in(Set(["a", "b", "c", "d"]))
+```
 
 When the property is of type `String`, `in` accepts a second parameter that determines how the string should be compared to the elements in the list.
 

--- a/README.md
+++ b/README.md
@@ -341,28 +341,21 @@ let predicate = \Note.numberOfViews ~= 100...200
 
 ###### in
 
-You can use the  `in`  function to determine whether a property's value is one of the values in a specified list.
+You can use the `in` function to determine whether a property's value is one of the values in a variadic arguments (comma-separated list), an array, or a set.
 
 
 ```swift
-// Matches all notes where the text is one of the elements in the specified list.
+// Matches all notes where the text is one of the elements in the specified variadic arguments list.
 let predicate = (\Note.text).in("a", "b", "c", "d")
-```
-or pass in an Array
 
-```swift
-// Matches all notes where the text is one of the elements in the specified list.
+// Matches all notes where the text is one of the elements in the specified array.
 let predicate = (\Note.text).in(["a", "b", "c", "d"])
-```
 
-or pass in a Set 
-
-```swift
-// Matches all notes where the text is one of the elements in the specified list.
+// Matches all notes where the text is one of the elements in the specified set.
 let predicate = (\Note.text).in(Set(["a", "b", "c", "d"]))
 ```
 
-When the property is of type `String`, `in` accepts a second parameter that determines how the string should be compared to the elements in the list.
+When the array `Element` is a `String`, `in` accepts a second parameter that determines how the string should be compared to the elements in the list.
 
 ```swift
 // Case-insensitive comparison.

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ let predicate = (\Note.text).in(["a", "b", "c", "d"])
 let predicate = (\Note.text).in(Set(["a", "b", "c", "d"]))
 ```
 
-When the array `Element` is a `String`, `in` accepts a second parameter that determines how the string should be compared to the elements in the list.
+When the property type is a `String`, `in` accepts a second parameter that determines how the string should be compared to the elements in the list.
 
 ```swift
 // Case-insensitive comparison.


### PR DESCRIPTION
this is because for values like Int64 passing an array to an IN expression is not allowed and requires variadic parameter