### PR TITLE
Add support for testing objects for equality

### DIFF
--- a/PredicateKit/CoreData/NSFetchRequestBuilder.swift
+++ b/PredicateKit/CoreData/NSFetchRequestBuilder.swift
@@ -302,6 +302,13 @@ extension Query: NSExpressionConvertible {
   }
 }
 
+extension ObjectIdentifier: NSExpressionConvertible where Object: NSExpressionConvertible {
+  func toNSExpression(options: NSExpressionConversionOptions) -> NSExpression {
+    let root = self.root.toNSExpression(options: options)
+    return NSExpression(format: "\(root).id")
+  }
+}
+
 // MARK: - Primitive
 
 private extension Primitive {

--- a/PredicateKit/Predicate.swift
+++ b/PredicateKit/Predicate.swift
@@ -313,6 +313,13 @@ public struct ArrayElementKeyPath<Array, Value>: Expression where Array: Express
   let elementKeyPath: AnyKeyPath
 }
 
+public struct ObjectIdentifier<Object: Expression, Identifier: Primitive>: Expression {
+  public typealias Root = Object
+  public typealias Value = Identifier
+
+  let root: Object
+}
+
 enum ComparisonOperator {
   case lessThan
   case lessThanOrEqual
@@ -369,6 +376,11 @@ public func <= <E: Expression, T: Comparable & Primitive> (lhs: E, rhs: T) -> Pr
 
 public func == <E: Expression, T: Equatable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
   .comparison(.init(lhs, .equal, rhs))
+}
+
+@available(iOS 13.0, *)
+public func == <E: Expression, T: Identifiable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.ID: Primitive {
+  .comparison(.init(ObjectIdentifier<E, T.ID>(root: lhs), .equal, rhs.id))
 }
 
 @_disfavoredOverload

--- a/PredicateKitTests/CoreDataTests/NSManagedObjectContextExtensionsTests.swift
+++ b/PredicateKitTests/CoreDataTests/NSManagedObjectContextExtensionsTests.swift
@@ -116,6 +116,27 @@ final class NSManagedObjectContextExtensionsTests: XCTestCase {
     XCTAssertNil(texts.first?["creationDate"])
   }
 
+  @available(iOS 13.0, *)
+  func testFetchWithObjectComparison() throws {
+    let attachment1 = try container.viewContext.insertAttachment("1")
+    let attachment2 = try container.viewContext.insertAttachment("2")
+
+    try container.viewContext.insertNotes(
+      (text: "Hello, World!", creationDate: Date(), numberOfViews: 42, tags: ["greeting"], attachment: attachment1 ),
+      (text: "Goodbye!", creationDate: Date(), numberOfViews: 3, tags: ["greeting"], attachment: attachment2 ),
+      (text: "See ya!", creationDate: Date(), numberOfViews: 3, tags: ["greeting"], attachment: attachment2 )
+    )
+
+    let notes: [Note] = try container.viewContext
+      .fetch(where: \Note.attachment == attachment1)
+      .result()
+
+    XCTAssertEqual(notes.count, 1)
+    XCTAssertEqual(notes.first?.text, "Hello, World!")
+    XCTAssertEqual(notes.first?.tags, ["greeting"])
+    XCTAssertEqual(notes.first?.numberOfViews, 42)
+  }
+
   func testFetchAll() throws {
     try container.viewContext.insertNotes(
       (text: "Hello, World!", creationDate: Date(), numberOfViews: 42, tags: ["greeting"]),
@@ -675,6 +696,7 @@ class Note: NSManagedObject {
   @NSManaged var updateDate: Date?
   @NSManaged var numberOfViews: Int
   @NSManaged var tags: [String]
+  @NSManaged var attachment: Attachment
 }
 
 class Account: NSManagedObject {
@@ -701,9 +723,13 @@ class Profile: NSManagedObject {
   @NSManaged var creationDate: Date
 }
 
+class Attachment: NSManagedObject, Identifiable {
+  @NSManaged var id: String
+}
+
 // MARK: -
 
-private extension XCTestCase {
+extension XCTestCase {
   func makePersistentContainer(with model: NSManagedObjectModel) -> NSPersistentContainer {
     let expectation = self.expectation(description: "container")
     let description = NSPersistentStoreDescription()
@@ -752,6 +778,24 @@ private extension NSManagedObjectContext {
     try save()
   }
 
+  func insertNotes(
+    _ notes: (text: String, creationDate: Date, numberOfViews: Int, tags: [String], attachment: Attachment?)...
+  ) throws {
+    for description in notes {
+      let note = NSEntityDescription.insertNewObject(forEntityName: "Note", into: self) as! Note
+      note.text = description.text
+      note.tags = description.tags
+      note.numberOfViews = description.numberOfViews
+      note.creationDate = description.creationDate
+
+      if let attachment = description.attachment {
+        note.attachment = attachment
+      }
+    }
+
+    try save()
+  }
+
   func insertAccounts(purchases: [[Double]]) throws {
     for description in purchases {
       let account = NSEntityDescription.insertNewObject(forEntityName: "Account", into: self) as! Account
@@ -791,6 +835,15 @@ private extension NSManagedObjectContext {
     }
 
     try save()
+  }
+
+  func insertAttachment(_ id: String) throws -> Attachment {
+    let attachment = NSEntityDescription.insertNewObject(forEntityName: "Attachment", into: self) as! Attachment
+    attachment.id = id
+
+    try save()
+
+    return attachment
   }
 
   func deleteAll<T: NSManagedObject>(_ type: T.Type) {

--- a/PredicateKitTests/OperatorTests.swift
+++ b/PredicateKitTests/OperatorTests.swift
@@ -236,6 +236,37 @@ final class OperatorTests: XCTestCase {
     XCTAssertEqual(value, 42)
   }
 
+  @available(iOS 13.0, *)
+  func testKeyPathEqualIdentifiable() throws {
+    struct Data {
+      let identifiable: IdentifiableData
+    }
+
+    struct IdentifiableData: Identifiable, Equatable {
+      let id: String
+    }
+
+    let predicate = \Data.identifiable == IdentifiableData(id: "1")
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("identifiable.id == 1 should result in a comparison")
+      return
+    }
+
+    guard
+      let expression = comparison.expression.as(ObjectIdentifier<KeyPath<Data, IdentifiableData>, String>.self)
+    else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+
+    let value = try XCTUnwrap(comparison.value as? IdentifiableData.ID)
+
+    XCTAssertEqual(expression.root, \Data.identifiable)
+    XCTAssertEqual(comparison.operator, .equal)
+    XCTAssertEqual(value, "1")
+  }
+
   func testOptionalKeyPathEqualToNil() throws {
     let predicate: Predicate<Data> = \Data.optionalRelationship == nil
 
@@ -2197,6 +2228,7 @@ private struct Data {
   let creationDate: Date
   let optionalRelationship: Relationship?
   let optionalRelationships: [Relationship]?
+  let identifiable: IdentifiableData?
 }
 
 private struct Relationship {

--- a/PredicateKitTests/Resources/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
+++ b/PredicateKitTests/Resources/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName=".Account" syncable="YES">
         <attribute name="purchases" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
+    </entity>
+    <entity name="Attachment" representedClassName=".Attachment" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
     </entity>
     <entity name="BillingInfo" representedClassName=".BillingInfo" syncable="YES">
         <attribute name="accountType" optional="YES" attributeType="String"/>
         <attribute name="purchases" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
+    </entity>
+    <entity name="IdentifiableData" representedClassName=".IdentifiableData" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Note" representedClassName=".Note" syncable="YES">
         <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -13,6 +19,7 @@
         <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="updateDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="attachment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Attachment"/>
     </entity>
     <entity name="Profile" representedClassName=".Profile" syncable="YES">
         <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -26,12 +33,4 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="profiles" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Profile"/>
     </entity>
-    <elements>
-        <element name="Account" positionX="0" positionY="0" width="128" height="44"/>
-        <element name="BillingInfo" positionX="0" positionY="0" width="128" height="59"/>
-        <element name="Note" positionX="0" positionY="0" width="128" height="104"/>
-        <element name="Profile" positionX="0" positionY="0" width="128" height="59"/>
-        <element name="User" positionX="0" positionY="0" width="128" height="59"/>
-        <element name="UserAccount" positionX="0" positionY="0" width="128" height="59"/>
-    </elements>
 </model>

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ class Note: NSManagedObject {
   @NSManaged var creationDate: Date
   @NSManaged var numberOfViews: Int
   @NSManaged var tags: [String]
+  @NSManaged var attachment: Attachment
 }
 
 // Matches all notes where the text is equal to "Hello, World!".
@@ -287,6 +288,9 @@ let predicate = \Note.creationDate < Date()
 
 // Matches all notes where the number of views is at least 120.
 let predicate = \Note.numberOfViews >= 120
+
+// Matches all notes having the specified attachment. `Attachment` must conform to `Identifiable`.
+let predicate = \Note.attachment == attachment
 ```
 
 #### String comparisons


### PR DESCRIPTION
Fixes #14 and #19. Adds support for testing equality of objects conforming to `Identifiable` with the `==` operator in predicates.

###### Example

```swift
class Note: NSManagedObject {
  @NSManaged var attachment: Attachment
}

class Attachment: NSManagedObject, Identifiable {
  @NSManaged var id: String
  ...
}

let attachment: Attachment = // ...
let predicate = \Note.attachment == attachment
```