### PR TITLE
Added SectionedFetchRequest handlers and updatePredicate to SwiftUI

### DIFF
--- a/PredicateKit.xcodeproj/project.pbxproj
+++ b/PredicateKit.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		32034734254CC05300F9661B /* MockNSFetchRequestInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNSFetchRequestInspector.swift; sourceTree = "<group>"; };
 		322517D72AEF7E85003DD2CD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = PredicateKit/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
 		32C8F72225B22CBE00903E22 /* SwiftUISupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupport.swift; sourceTree = "<group>"; };
-		32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupportTests.swift; sourceTree = "<group>"; };
+		32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = SwiftUISupportTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/PredicateKit/SwiftUI/SwiftUISupport.swift
+++ b/PredicateKit/SwiftUI/SwiftUISupport.swift
@@ -164,3 +164,137 @@ extension FetchRequest {
     self.init(predicate: true)
   }
 }
+
+@available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
+extension FetchedResults where Result: NSManagedObject {
+  /// Changes the `Predicate` used in filtering the `@SwiftUI.FetchRequest` property.
+  ///
+  /// - Parameter newPredicate: The predicate used to define a filter for the fetched results.
+  ///
+  /// ## Example
+  ///
+  ///     struct ContentView: View {
+  ///       @SwiftUI.FetchRequest(predicate: \Note.text == "Hello, World!")
+  ///       var notes: FetchedResults<Note>
+  ///
+  ///       var body: some View {
+  ///         List(notes, id: \.self) {
+  ///           Text($0.text)
+  ///         }
+  ///         Button("Show All") {
+  ///           _notes.updatePredicate(true)
+  ///         }
+  ///       }
+  ///
+  public func updatePredicate(_ newPredicate: Predicate<Result>) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    let dummyRequest = FetchRequest(predicate: newPredicate)
+    let nsFetchRequest: NSFetchRequest<Result> = fetchRequestBuilder.makeRequest(from: dummyRequest)
+    self.nsPredicate = nsFetchRequest.predicate
+  }
+}
+
+@available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
+extension SectionedFetchRequest where Result: NSManagedObject {
+  /// Creates an instance from the provided fetch request and animation.
+  ///
+  /// - Parameter fetchRequest: The request used to produce the fetched results.
+  /// - Parameter sectionIdentifier: A key path that SwiftUI applies to the Result type to get an object’s section identifier.
+  /// - Parameter animation: The animation used for any changes to the fetched results.
+  ///
+  /// ## Example
+  ///
+  ///      struct ContentView: View {
+  ///        @SwiftUI.SectionedFetchRequest(
+  ///          fetchRequest: FetchRequest(predicate: \User.name == "John Doe"),
+  ///          sectionIdentifier: \.billingInfo.accountType
+  ///        )
+  ///        var users: SectionedFetchResults<String, User>
+  ///
+  ///        var body: some View {
+  ///          List(users, id: \.id) { section in
+  ///            Section(section.id) {
+  ///              ForEach(section, id: \.objectID) { user in
+  ///                Text(user.name)
+  ///              }
+  ///            }
+  ///          }
+  ///        }
+  ///
+  public init(fetchRequest: FetchRequest<Result>, sectionIdentifier: KeyPath<Result, SectionIdentifier>, animation: Animation? = nil) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    self.init(fetchRequest: fetchRequestBuilder.makeRequest(from: fetchRequest), sectionIdentifier: sectionIdentifier, animation: animation)
+  }
+
+  /// Creates an instance from the provided fetch request and transaction.
+  ///
+  /// - Parameter fetchRequest: The request used to produce the fetched results.
+  /// - Parameter sectionIdentifier: A key path that SwiftUI applies to the Result type to get an object’s section identifier.
+  /// - Parameter transaction: The transaction used for any changes to the fetched results.
+  ///
+  /// ## Example
+  ///
+  ///      struct ContentView: View {
+  ///        @SwiftUI.SectionedFetchRequest(
+  ///          fetchRequest: FetchRequest(predicate: \User.name == "John Doe"),
+  ///          sectionIdentifier: \.billingInfo.accountType
+  ///          transaction: Transaction(animation: .easeIn)
+  ///        )
+  ///        var users: SectionedFetchResults<String, User>
+  ///
+  ///        var body: some View {
+  ///          List(users, id: \.id) { section in
+  ///            Section(section.id) {
+  ///              ForEach(section, id: \.objectID) { user in
+  ///                Text(user.name)
+  ///              }
+  ///            }
+  ///          }
+  ///        }
+  ///
+  public init(fetchRequest: FetchRequest<Result>, sectionIdentifier: KeyPath<Result, SectionIdentifier>, transaction: Transaction) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    self.init(fetchRequest: fetchRequestBuilder.makeRequest(from: fetchRequest), sectionIdentifier: sectionIdentifier, transaction: transaction)
+  }
+}
+
+@available(iOS 15.0, watchOS 8.0, tvOS 15.0, macOS 12.0, *)
+extension SectionedFetchResults where Result: NSManagedObject {
+  /// Changes the `Predicate` used in filtering the `@SwiftUI.FetchRequest` property.
+  ///
+  /// - Parameter newPredicate: The predicate used to define a filter for the fetched results.
+  ///
+  /// ## Example
+  ///
+  ///      struct ContentView: View {
+  ///        @SwiftUI.SectionedFetchRequest(
+  ///          fetchRequest: FetchRequest(predicate: \User.name == "John Doe"),
+  ///          sectionIdentifier: \.billingInfo.accountType
+  ///          transaction: Transaction(animation: .easeIn)
+  ///        )
+  ///        var users: SectionedFetchResults<String, User>
+  ///
+  ///        var body: some View {
+  ///          List(users, id: \.id) { section in
+  ///            Section(section.id) {
+  ///              ForEach(section, id: \.objectID) { user in
+  ///                Text(user.name)
+  ///              }
+  ///            }
+  ///          }
+  ///          Button("Show All") {
+  ///            _users.updatePredicate(true)
+  ///          }
+  ///        }
+  ///
+  public func updatePredicate(_ newPredicate: Predicate<Result>) {
+    let entityName = Result.entity().name ?? String(describing: Result.self)
+    let fetchRequestBuilder = NSFetchRequestBuilder(entityName: entityName)
+    let dummyRequest = FetchRequest(predicate: newPredicate)
+    let nsFetchRequest: NSFetchRequest<Result> = fetchRequestBuilder.makeRequest(from: dummyRequest)
+    self.nsPredicate = nsFetchRequest.predicate
+  }
+}


### PR DESCRIPTION
Continuing from https://github.com/ftchirou/PredicateKit/issues/24

Added functionality for SwiftUI `SectionedFetchRequest` (very similar to `FetchRequest` property wrapper, but with sections).

Also added `updatePredicate(_:)` functions to `FetchedResults` and `SectionedFetchResults` so that the wrapped property can have its predicates updated dynamically.

Added test for `FetchRequest.updatePredicate(_:)`, but the tests for `SectionedFetchRequest` will need another type of test (see the issue link for details).