### PR TITLE
Add support for comparing raw representables

### DIFF
--- a/PredicateKit.podspec
+++ b/PredicateKit.podspec
@@ -15,7 +15,7 @@
 
 Pod::Spec.new do |spec|
   spec.name = "PredicateKit"
-  spec.version = "1.8.0"
+  spec.version = "1.9.0"
   spec.summary = "Write expressive and type-safe predicates for CoreData using key-paths, comparisons and logical operators, literal values, and functions."
   spec.description = <<-DESC
   PredicateKit allows Swift developers to write expressive and type-safe predicates for CoreData using key-paths, comparisons and logical operators, literal values, and functions.

--- a/PredicateKit.xcodeproj/project.pbxproj
+++ b/PredicateKit.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -445,6 +446,7 @@
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/PredicateKit.xcodeproj/project.pbxproj
+++ b/PredicateKit.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		3203470F2548C54200F9661B /* DataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3203470D2548C54200F9661B /* DataModel.xcdatamodeld */; };
 		320347132548EE4B00F9661B /* Functions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320347122548EE4B00F9661B /* Functions.swift */; };
 		32034719254903B700F9661B /* XCTestCaseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32034718254903B700F9661B /* XCTestCaseExtensions.swift */; };
-		320347252549A66E00F9661B /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 320347242549A66E00F9661B /* README.md */; };
 		3203472D254C952600F9661B /* NSFetchRequestInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3203472C254C952500F9661B /* NSFetchRequestInspector.swift */; };
 		32034735254CC05300F9661B /* MockNSFetchRequestInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32034734254CC05300F9661B /* MockNSFetchRequestInspector.swift */; };
 		322517D82AEF7E85003DD2CD /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 322517D72AEF7E85003DD2CD /* PrivacyInfo.xcprivacy */; };
@@ -59,6 +58,8 @@
 		3203472C254C952500F9661B /* NSFetchRequestInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSFetchRequestInspector.swift; sourceTree = "<group>"; };
 		32034734254CC05300F9661B /* MockNSFetchRequestInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNSFetchRequestInspector.swift; sourceTree = "<group>"; };
 		322517D72AEF7E85003DD2CD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = PredicateKit/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
+		32B8E6552B948E5100512327 /* PredicateKit.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PredicateKit.podspec; sourceTree = "<group>"; };
+		32B8E6572B948E7900512327 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		32C8F72225B22CBE00903E22 /* SwiftUISupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupport.swift; sourceTree = "<group>"; };
 		32C8F75425B248C700903E22 /* SwiftUISupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISupportTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -89,6 +90,8 @@
 				320346692546AA5400F9661B /* PredicateKitTests */,
 				3203465D2546AA5400F9661B /* Products */,
 				320347242549A66E00F9661B /* README.md */,
+				32B8E6572B948E7900512327 /* Package.swift */,
+				32B8E6552B948E5100512327 /* PredicateKit.podspec */,
 			);
 			sourceTree = "<group>";
 		};
@@ -282,7 +285,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				320347252549A66E00F9661B /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PredicateKit/CoreData/NSFetchRequestBuilder.swift
+++ b/PredicateKit/CoreData/NSFetchRequestBuilder.swift
@@ -81,7 +81,7 @@ struct NSFetchRequestBuilder {
       case .none:
         return NSCompoundPredicate(notPredicateWithSubpredicate: NSComparisonPredicate(
           leftExpression: makeExpression(from: comparison.expression),
-          rightExpression: NSExpression(forConstantValue: comparison.value),
+          rightExpression: makeExpression(from: comparison.value),
           modifier: makeComparisonModifier(from: comparison.modifier),
           type: makeOperator(from: comparison.operator),
           options: makeComparisonOptions(from: comparison.options)
@@ -111,7 +111,7 @@ struct NSFetchRequestBuilder {
   }
 
   private func makeExpression(from primitive: Primitive) -> NSExpression {
-    return NSExpression(forConstantValue: primitive.value)
+    return NSExpression(forConstantValue: primitive.predicateValue)
   }
 
   private func makeOperator(from operator: ComparisonOperator) -> NSComparisonPredicate.Operator {
@@ -306,19 +306,6 @@ extension ObjectIdentifier: NSExpressionConvertible where Object: NSExpressionCo
   func toNSExpression(options: NSExpressionConversionOptions) -> NSExpression {
     let root = self.root.toNSExpression(options: options)
     return NSExpression(format: "\(root).id")
-  }
-}
-
-// MARK: - Primitive
-
-private extension Primitive {
-  var value: Any? {
-    switch Self.type {
-    case .nil:
-      return NSNull()
-    default:
-      return self
-    }
   }
 }
 

--- a/PredicateKit/Predicate.swift
+++ b/PredicateKit/Predicate.swift
@@ -371,12 +371,25 @@ public func < <E: Expression, T: Comparable & Primitive> (lhs: E, rhs: T) -> Pre
   .comparison(.init(lhs, .lessThan, rhs))
 }
 
+public func < <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Comparable & Primitive {
+  .comparison(.init(lhs, .lessThan, rhs.rawValue))
+}
+
 public func <= <E: Expression, T: Comparable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
   .comparison(.init(lhs, .lessThanOrEqual, rhs))
 }
 
+public func <= <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Comparable & Primitive {
+  .comparison(.init(lhs, .lessThanOrEqual, rhs.rawValue))
+}
+
+
 public func == <E: Expression, T: Equatable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
   .comparison(.init(lhs, .equal, rhs))
+}
+
+public func == <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Equatable & Primitive {
+  .comparison(.init(lhs, .equal, rhs.rawValue))
 }
 
 @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -397,8 +410,16 @@ public func >= <E: Expression, T: Comparable & Primitive> (lhs: E, rhs: T) -> Pr
   .comparison(.init(lhs, .greaterThanOrEqual, rhs))
 }
 
+public func >= <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Comparable & Primitive {
+  .comparison(.init(lhs, .greaterThanOrEqual, rhs.rawValue))
+}
+
 public func > <E: Expression, T: Comparable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
   .comparison(.init(lhs, .greaterThan, rhs))
+}
+
+public func > <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Comparable & Primitive {
+  .comparison(.init(lhs, .greaterThan, rhs.rawValue))
 }
 
 // MARK: - Compound Predicates

--- a/PredicateKit/Primitive.swift
+++ b/PredicateKit/Primitive.swift
@@ -24,6 +24,7 @@ import Foundation
 
 public protocol Primitive {
   static var type: Type { get }
+  var predicateValue: Any? { get }
 }
 
 public indirect enum Type: Equatable {
@@ -48,6 +49,10 @@ public indirect enum Type: Equatable {
   case wrapped(Type)
   case array(Type)
   case `nil`
+}
+
+extension Primitive {
+  public var predicateValue: Any? { self }
 }
 
 extension Bool: Primitive {
@@ -110,8 +115,12 @@ extension Date: Primitive {
   public static var type: Type { .date }
 }
 
+// TODO: Potentially remove this in the next major version. RawRepresentables (with primitive
+// raw values) can already be used in predicates without explicitly conforming to Primitive.
 extension Primitive where Self: RawRepresentable, RawValue: Primitive {
   public static var type: Type { RawValue.type }
+
+  public var predicateValue: Any? { rawValue }
 }
 
 extension Array: Primitive where Element: Primitive {
@@ -136,6 +145,8 @@ extension Optional: Primitive where Wrapped: Primitive {
 
 public struct Nil: Primitive, ExpressibleByNilLiteral {
   public static var type: Type { .nil }
+
+  public var predicateValue: Any? { NSNull() }
 
   public init(nilLiteral: ()) {
   }

--- a/PredicateKitTests/CoreDataTests/NSFetchRequestBuilderTests.swift
+++ b/PredicateKitTests/CoreDataTests/NSFetchRequestBuilderTests.swift
@@ -130,6 +130,136 @@ final class NSFetchRequestBuilderTests: XCTestCase {
     XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
   }
 
+  func testEqualityWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType == .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .equalTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testLessThanWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType < .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testLessThanOrEqualWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType <= .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThanOrEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testGreaterThanWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType > .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .greaterThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testGreaterThanOrEqualWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType >= .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .greaterThanOrEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testEqualityWithRawRepresentableConformingToPrimitive() throws {
+    let request = makeRequest(\Data.primitiveDataType == .three)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "primitiveDataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: PrimitiveDataType.three.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .equalTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testLessThanWithRawRepresentableConformingToPrimitive() throws {
+    let request = makeRequest(\Data.primitiveDataType < .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "primitiveDataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: PrimitiveDataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testLessThanOrEqualWithRawRepresentableConformingToPrimitive() throws {
+    let request = makeRequest(\Data.primitiveDataType <= .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "primitiveDataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: PrimitiveDataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .lessThanOrEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testGreaterThanWithRawRepresentableConformingToPrimitive() throws {
+    let request = makeRequest(\Data.primitiveDataType > .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "primitiveDataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: PrimitiveDataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .greaterThan)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testGreaterThanOrEqualWithRawRepresentableConformingToPrimitive() throws {
+    let request = makeRequest(\Data.primitiveDataType >= .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "primitiveDataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: PrimitiveDataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .greaterThanOrEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
   func testArrayElementEqualPredicate() throws {
     let request = makeRequest((\Data.relationships).last(\.count) == 42)
     let builder = makeRequestBuilder()
@@ -1156,12 +1286,28 @@ private class Data: NSManagedObject {
   @NSManaged var optionalRelationships: [Relationship]?
   @NSManaged var identifiable: IdentifiableData
   @NSManaged var optionalIdentifiable: IdentifiableData?
+  @NSManaged var dataType: DataType
+  @NSManaged var primitiveDataType: PrimitiveDataType
 }
 
 private class Relationship: NSManagedObject {
   @NSManaged var text: String
   @NSManaged var stocks: [Double]
   @NSManaged var count: Int
+}
+
+@objc private enum DataType: Int {
+  case zero
+  case one
+  case two
+  case three
+}
+
+@objc private enum PrimitiveDataType: Int, Primitive {
+  case zero
+  case one
+  case two
+  case three
 }
 
 private class DataStore: NSAtomicStore {

--- a/PredicateKitTests/Resources/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
+++ b/PredicateKitTests/Resources/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName=".Account" syncable="YES">
         <attribute name="purchases" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
     </entity>
@@ -18,6 +18,7 @@
         <attribute name="numberOfViews" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
         <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="updateDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="attachment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Attachment"/>
     </entity>

--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ class Note: NSManagedObject {
   @NSManaged var numberOfViews: Int
   @NSManaged var tags: [String]
   @NSManaged var attachment: Attachment
+  @NSManaged var type: NoteType
+}
+
+class Attachment: NSManagedObject, Identifiable {
+  // ...
+}
+
+@objc enum NoteType: Int {
+  case freeForm
+  // ...
 }
 
 // Matches all notes where the text is equal to "Hello, World!".
@@ -289,8 +299,11 @@ let predicate = \Note.creationDate < Date()
 // Matches all notes where the number of views is at least 120.
 let predicate = \Note.numberOfViews >= 120
 
-// Matches all notes having the specified attachment. `Attachment` must conform to `Identifiable`.
+// Matches all notes having the specified attachment (`Attachment` must conform to `Identifiable`).
 let predicate = \Note.attachment == attachment
+
+// Matches all free form notes (assuming `NoteType` is an enumeration whose `RawValue` conforms to `Equatable`).
+let predicate = \Note.type == .freeForm
 ```
 
 #### String comparisons


### PR DESCRIPTION
Make it straightforward to use enumerations (and other raw representables) in predicates.

##### Example

```swift
class Note: NSManagedObject {
  // ...
  @NSManaged var type: NoteType
}

@objc enum NoteType: Int {
  case freeForm
  case structured
}
```

```swift
let predicate = \Note.type == .structured
```

Previously, this 👆predicate would have required `NoteType` to conform to `Primitive` to compile. Not anymore.