### PR TITLE
Allow enums, identifiables, and nils for notEqual

### DIFF
--- a/PredicateKit/Predicate.swift
+++ b/PredicateKit/Predicate.swift
@@ -383,7 +383,6 @@ public func <= <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicat
   .comparison(.init(lhs, .lessThanOrEqual, rhs.rawValue))
 }
 
-
 public func == <E: Expression, T: Equatable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
   .comparison(.init(lhs, .equal, rhs))
 }
@@ -403,6 +402,20 @@ public func == <E: Expression> (lhs: E, rhs: Nil) -> Predicate<E.Root> where E.V
 }
 
 public func != <E: Expression, T: Equatable & Primitive> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T {
+  .comparison(.init(lhs, .notEqual, rhs))
+}
+
+public func != <E: Expression, T: RawRepresentable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.RawValue: Equatable & Primitive {
+  .comparison(.init(lhs, .notEqual, rhs.rawValue))
+}
+
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func != <E: Expression, T: Identifiable> (lhs: E, rhs: T) -> Predicate<E.Root> where E.Value == T, T.ID: Primitive {
+  .comparison(.init(ObjectIdentifier<E, T.ID>(root: lhs), .notEqual, rhs.id))
+}
+
+@_disfavoredOverload
+public func != <E: Expression> (lhs: E, rhs: Nil) -> Predicate<E.Root> where E.Value: OptionalType {
   .comparison(.init(lhs, .notEqual, rhs))
 }
 

--- a/PredicateKitTests/CoreDataTests/NSFetchRequestBuilderTests.swift
+++ b/PredicateKitTests/CoreDataTests/NSFetchRequestBuilderTests.swift
@@ -283,6 +283,61 @@ final class NSFetchRequestBuilderTests: XCTestCase {
     XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
   }
 
+  @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  func testNotEqualWithIdentifiable() throws {
+    guard let identifiable = makeIdentifiable() else {
+      XCTFail("could not initialize IdentifiableData")
+      return
+    }
+
+    identifiable.id = "42"
+
+    let request = makeRequest(\Data.identifiable != identifiable)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "identifiable.id"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: "42"))
+    XCTAssertEqual(comparison.predicateOperatorType, .notEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  func testNotEqualWithOptionalIdentifiable() throws {
+    guard let identifiable = makeIdentifiable() else {
+      XCTFail("could not initialize IdentifiableData")
+      return
+    }
+
+    identifiable.id = "42"
+
+    let request = makeRequest(\Data.optionalIdentifiable != identifiable)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "optionalIdentifiable.id"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: "42"))
+    XCTAssertEqual(comparison.predicateOperatorType, .notEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
+  func testNotEqualWithRawRepresentable() throws {
+    let request = makeRequest(\Data.dataType != .two)
+    let builder = makeRequestBuilder()
+
+    let result: NSFetchRequest<Data> = builder.makeRequest(from: request)
+
+    let comparison = try XCTUnwrap(result.predicate as? NSComparisonPredicate)
+    XCTAssertEqual(comparison.leftExpression, NSExpression(forKeyPath: "dataType"))
+    XCTAssertEqual(comparison.rightExpression, NSExpression(forConstantValue: DataType.two.rawValue))
+    XCTAssertEqual(comparison.predicateOperatorType, .notEqualTo)
+    XCTAssertEqual(comparison.comparisonPredicateModifier, .direct)
+  }
+
   func testArrayElementNotEqualPredicate() throws {
     let request = makeRequest((\Data.relationships).last(\.count) != 42)
     let builder = makeRequestBuilder()

--- a/PredicateKitTests/OperatorTests.swift
+++ b/PredicateKitTests/OperatorTests.swift
@@ -268,6 +268,37 @@ final class OperatorTests: XCTestCase {
     XCTAssertEqual(value, "1")
   }
 
+  func testKeyPathEqualRawRepresentable() throws {
+    struct Data {
+      let rawRepresentable: RawRepresentableValue
+    }
+
+    enum RawRepresentableValue: Int {
+      case zero
+      case one
+    }
+
+    let predicate = \Data.rawRepresentable == .zero
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("rawRepresentable == .zero should result in a comparison")
+      return
+    }
+
+    guard
+      let expression = comparison.expression.as(KeyPath<Data, RawRepresentableValue>.self)
+    else {
+      XCTFail("the left side of the comparison should be a key path")
+      return
+    }
+
+    let value = try XCTUnwrap(comparison.value as? RawRepresentableValue.RawValue)
+
+    XCTAssertEqual(expression, \Data.rawRepresentable)
+    XCTAssertEqual(comparison.operator, .equal)
+    XCTAssertEqual(value, 0)
+  }
+
   func testOptionalKeyPathEqualToNil() throws {
     let predicate: Predicate<Data> = \Data.optionalRelationship == nil
 
@@ -470,6 +501,104 @@ final class OperatorTests: XCTestCase {
     XCTAssertEqual(keyPath.elementKeyPath, \Relationship.count)
     XCTAssertEqual(comparison.operator, .notEqual)
     XCTAssertEqual(value, 5)
+  }
+
+  @available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  func testKeyPathNotEqualIdentifiable() throws {
+    struct Data {
+      let identifiable: IdentifiableData
+    }
+
+    struct IdentifiableData: Identifiable, Equatable {
+      let id: String
+    }
+
+    let predicate = \Data.identifiable != IdentifiableData(id: "1")
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("identifiable.id != 1 should result in a comparison")
+      return
+    }
+
+    guard
+      let expression = comparison.expression.as(ObjectIdentifier<KeyPath<Data, IdentifiableData>, String>.self)
+    else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+
+    let value = try XCTUnwrap(comparison.value as? IdentifiableData.ID)
+
+    XCTAssertEqual(expression.root, \Data.identifiable)
+    XCTAssertEqual(comparison.operator, .notEqual)
+    XCTAssertEqual(value, "1")
+  }
+
+  func testKeyPathNotEqualRawRepresentable() throws {
+    struct Data {
+      let rawRepresentable: RawRepresentableValue
+    }
+
+    enum RawRepresentableValue: Int {
+      case zero
+      case one
+    }
+
+    let predicate = \Data.rawRepresentable != .zero
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("rawRepresentable != .zero should result in a comparison")
+      return
+    }
+
+    guard
+      let expression = comparison.expression.as(KeyPath<Data, RawRepresentableValue>.self)
+    else {
+      XCTFail("the left side of the comparison should be a key path")
+      return
+    }
+
+    let value = try XCTUnwrap(comparison.value as? RawRepresentableValue.RawValue)
+
+    XCTAssertEqual(expression, \Data.rawRepresentable)
+    XCTAssertEqual(comparison.operator, .notEqual)
+    XCTAssertEqual(value, 0)
+  }
+
+  func testOptionalKeyPathNotEqualToNil() throws {
+    let predicate: Predicate<Data> = \Data.optionalRelationship != nil
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("optionalRelationship != nil should result in a comparison")
+      return
+    }
+
+    guard let keyPath = comparison.expression.as(KeyPath<Data, Relationship?>.self) else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+
+    XCTAssertEqual(keyPath, \Data.optionalRelationship)
+    XCTAssertEqual(comparison.operator, .notEqual)
+    XCTAssertNotNil(comparison.value as? Nil)
+  }
+
+  func testOptionalArrayKeyPathNotEqualToNil() throws {
+    let predicate: Predicate<Data> = \Data.optionalRelationships != nil
+
+    guard case let .comparison(comparison) = predicate else {
+      XCTFail("optionalRelationships != nil should result in a comparison")
+      return
+    }
+
+    guard let keyPath = comparison.expression.as(KeyPath<Data, [Relationship]?>.self) else {
+      XCTFail("the left side of the comparison should be a key path expression")
+      return
+    }
+
+    XCTAssertEqual(keyPath, \Data.optionalRelationships)
+    XCTAssertEqual(comparison.operator, .notEqual)
+    XCTAssertNotNil(comparison.value as? Nil)
   }
 
   // MARK: - >=


### PR DESCRIPTION
Extend `!=` to handle `RawRepresentable`s, `Identifiable`s, and `nil`s on the right hand side.